### PR TITLE
[Page layouts] Updates to [EuiSideNav] (#4488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.7.0`.
+- Added `truncate`, `disabled`, and `emphasize` props to `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
+- Added `truncate` prop to `EuiSideNav` ([#4488](https://github.com/elastic/eui/pull/4488))
+
+**Bug fixes**
+
+- Fixed nested indicator of last `EuiSideNav` item ([#4488](https://github.com/elastic/eui/pull/4488))
+- Fixed override possibility of text `color` in `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
+
+**Theme: Amsterdam**
+
+- Removed letter-spacing from `euiFont` Sass mixin ([#4488](https://github.com/elastic/eui/pull/4488))
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/src-docs/src/views/side_nav/side_nav_complex.js
+++ b/src-docs/src/views/side_nav/side_nav_complex.js
@@ -43,7 +43,7 @@ export default () => {
       items: [
         createItem('Advanced settings', {
           items: [
-            createItem('General'),
+            createItem('General', { disabled: true }),
             createItem('Timelion', {
               items: [
                 createItem('Time stuff', {

--- a/src-docs/src/views/side_nav/side_nav_emphasis.js
+++ b/src-docs/src/views/side_nav/side_nav_emphasis.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+import { EuiSideNav } from '../../../../src/components';
+
+export default () => {
+  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
+  const [selectedItemName, setSelectedItem] = useState('Transactions');
+
+  const toggleOpenOnMobile = () => {
+    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+  };
+
+  const selectItem = (name) => {
+    setSelectedItem(name);
+  };
+
+  const createItem = (name, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      ...data,
+      id: name,
+      name,
+      isSelected: selectedItemName === name,
+      onClick: () => selectItem(name),
+    };
+  };
+
+  const sideNav = [
+    createItem('APM', {
+      items: [
+        createItem('Services', {
+          items: [
+            createItem('opbeans-java', {
+              emphasize: true,
+              isOpen: true,
+              items: [
+                createItem('Transactions'),
+                createItem('Errors'),
+                createItem('JVMs'),
+              ],
+            }),
+          ],
+        }),
+        createItem('Traces'),
+        createItem('Service map'),
+      ],
+    }),
+  ];
+
+  return (
+    <EuiSideNav
+      aria-label="Emphasized side nav example"
+      mobileTitle="Navigate within $APP_NAME"
+      toggleOpenOnMobile={toggleOpenOnMobile}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      items={sideNav}
+      style={{ width: 192, overflow: 'hidden' }}
+    />
+  );
+};

--- a/src-docs/src/views/side_nav/side_nav_example.js
+++ b/src-docs/src/views/side_nav/side_nav_example.js
@@ -160,7 +160,49 @@ const sideNavForceSnippet = `<EuiSideNav
 />
 `;
 
+import SideNavEmphasis from './side_nav_emphasis';
+const sideNavEmphasisSource = require('!!raw-loader!./side_nav_emphasis');
+const sideNavEmphasisHtml = renderToHtml(SideNavEmphasis);
+const sideNavEmphasisSnippet = `<EuiSideNav
+  mobileTitle="Navbar Items"
+  toggleOpenOnMobile={toggleOpenOnMobile}
+  isOpenOnMobile={isSideNavOpenOnMobile}
+  items={[
+    {
+      name: 'APM',
+      id: '1',
+      items: [
+        {
+          name: 'Services',
+          id: '2',
+          items: [
+            {
+              name: 'opbeans-java',
+              emphasize: true,
+              isOpen: true,
+              items: [
+                {
+                  name: 'Transactions',
+                  id: '0.1.1',
+                  onClick: () => selectItem('General'),
+                },
+                {
+                  name: 'Errors',
+                  id: '0.1.2',
+                  onClick: () => selectItem('Timelion'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+`;
+
 import { SideNavItem } from './props';
+import { EuiCallOut } from '../../../../src/components/call_out';
 
 export const SideNavExample = {
   title: 'Side nav',
@@ -210,8 +252,8 @@ export const SideNavExample = {
       ],
       text: (
         <p>
-          <strong>EuiSideNav</strong> also supports deeply-nested tree-based
-          data.
+          <strong>EuiSideNav</strong> also supports multiple top level sections
+          and deeply-nested tree-based data.
         </p>
       ),
       snippet: sideNavComplexSnippet,
@@ -237,6 +279,41 @@ export const SideNavExample = {
       ),
       snippet: sideNavForceSnippet,
       demo: <SideNavForceOpen />,
+    },
+    {
+      title: 'Emphasized side nav sections',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: sideNavEmphasisSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: sideNavEmphasisHtml,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            Adding the <EuiCode>emphasize = true</EuiCode> prop to a{' '}
+            <strong>EuiSideNav</strong> item will enhance the visual appearance
+            of that section and its nested items. This is helpful for when you
+            need to indicate a dynamic navigational item like a user-created
+            object.
+          </p>
+          <EuiCallOut iconType="editorCodeBlock" title="Extra style needed">
+            <p>
+              The emphasized nav item&apos;s background color extends beyond the
+              horizontal bounds of the component to allow it to reach it&apos;s
+              parents bounds. Be sure to add{' '}
+              <EuiCode language="sass">{'overflow: hidden'}</EuiCode> to
+              whichever container you&apos;d like it to stop at.
+            </p>
+          </EuiCallOut>
+        </>
+      ),
+      snippet: sideNavEmphasisSnippet,
+      demo: <SideNavEmphasis />,
     },
   ],
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -293,7 +293,7 @@ export {
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable';
 
-export { EuiSideNav } from './side_nav';
+export { EuiSideNav, EuiSideNavProps } from './side_nav';
 
 export { EuiSpacer } from './spacer';
 

--- a/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
@@ -7,19 +7,18 @@ exports[`EuiSideNav is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -34,19 +33,18 @@ exports[`EuiSideNav props isOpenOnMobile defaults to false 1`] = `
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -61,19 +59,18 @@ exports[`EuiSideNav props isOpenOnMobile is rendered when specified as true 1`] 
   class="euiSideNav euiSideNav-isOpenMobile"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -88,19 +85,18 @@ exports[`EuiSideNav props items is rendered 1`] = `
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -117,7 +113,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
           class="euiSideNavItemButton__content"
         >
           <span
-            class="euiSideNavItemButton__label"
+            class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
           >
             A
           </span>
@@ -127,16 +123,18 @@ exports[`EuiSideNav props items is rendered 1`] = `
         class="euiSideNavItem__items"
       >
         <div
-          class="euiSideNavItem euiSideNavItem--trunk"
+          class="euiSideNavItem euiSideNavItem--trunk class"
         >
           <div
+            aria-label="aria"
             class="euiSideNavItemButton"
+            data-test-sub="dts"
           >
             <span
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 B
               </span>
@@ -144,7 +142,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
           </div>
         </div>
         <div
-          class="euiSideNavItem euiSideNavItem--trunk"
+          class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--emphasized"
         >
           <div
             class="euiSideNavItemButton"
@@ -175,19 +173,18 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -204,7 +201,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
           class="euiSideNavItemButton__content"
         >
           <span
-            class="euiSideNavItemButton__label"
+            class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
           >
             A
           </span>
@@ -223,7 +220,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 B
               </span>
@@ -240,7 +237,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 C
               </span>
@@ -259,7 +256,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                   class="euiSideNavItemButton__content"
                 >
                   <span
-                    class="euiSideNavItemButton__label"
+                    class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
                   >
                     D
                   </span>
@@ -278,7 +275,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                       class="euiSideNavItemButton__content"
                     >
                       <span
-                        class="euiSideNavItemButton__label"
+                        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
                       >
                         E
                       </span>
@@ -300,19 +297,18 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -331,7 +327,7 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
           class="euiSideNavItemButton__content"
         >
           <span
-            class="euiSideNavItemButton__label"
+            class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
           >
             A
           </span>
@@ -351,7 +347,7 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 B
               </span>
@@ -369,19 +365,18 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -400,7 +395,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
           class="euiSideNavItemButton__content"
         >
           <span
-            class="euiSideNavItemButton__label"
+            class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
           >
             A
           </span>
@@ -419,7 +414,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 B
               </span>
@@ -436,7 +431,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 C
               </span>
@@ -458,19 +453,18 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
   class="euiSideNav"
 >
   <button
-    class="euiSideNav__mobileToggle euiLink"
+    class="euiButtonEmpty euiButtonEmpty--primary euiSideNav__mobileToggle"
     type="button"
   >
     <span
-      class="euiSideNav__mobileWrap"
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
     >
       <span
-        class="euiSideNav__mobileTitle"
+        class="euiButtonContent__icon"
+        data-euiicon-type="apps"
       />
       <span
-        aria-hidden="true"
-        class="euiSideNav__mobileIcon"
-        data-euiicon-type="apps"
+        class="euiButtonEmpty__text"
       />
     </span>
   </button>
@@ -487,7 +481,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
           class="euiSideNavItemButton__content"
         >
           <span
-            class="euiSideNavItemButton__label"
+            class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
           >
             A
           </span>
@@ -506,7 +500,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 B
               </span>
@@ -523,7 +517,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItemButton__content"
             >
               <span
-                class="euiSideNavItemButton__label"
+                class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
               >
                 C
               </span>
@@ -542,7 +536,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
                   class="euiSideNavItemButton__content"
                 >
                   <span
-                    class="euiSideNavItemButton__label"
+                    class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
                   >
                     D
                   </span>
@@ -559,7 +553,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
                   class="euiSideNavItemButton__content"
                 >
                   <span
-                    class="euiSideNavItemButton__label"
+                    class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
                   >
                     E
                   </span>

--- a/src/components/side_nav/__snapshots__/side_nav_item.test.tsx.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_item.test.tsx.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiSideNavItem can be disabled 1`] = `
+<div
+  class="euiSideNavItem euiSideNavItem--root"
+>
+  <button
+    class="euiSideNavItemButton"
+    disabled=""
+    type="button"
+  >
+    <span
+      class="euiSideNavItemButton__content"
+    >
+      <span
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+      >
+        Children
+      </span>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`EuiSideNavItem can be emphasized 1`] = `
+<div
+  class="euiSideNavItem euiSideNavItem--root euiSideNavItem--emphasized"
+>
+  <div
+    class="euiSideNavItemButton"
+  >
+    <span
+      class="euiSideNavItemButton__content"
+    >
+      <span
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+      >
+        Children
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`EuiSideNavItem can have truncation turned off 1`] = `
+<div
+  class="euiSideNavItem euiSideNavItem--root"
+>
+  <div
+    class="euiSideNavItemButton"
+  >
+    <span
+      class="euiSideNavItemButton__content"
+    >
+      <span
+        class="euiSideNavItemButton__label"
+      >
+        Children
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`EuiSideNavItem href is rendered 1`] = `
 <div
   class="euiSideNavItem euiSideNavItem--root"
@@ -13,7 +75,7 @@ exports[`EuiSideNavItem href is rendered 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button />
       </span>
@@ -35,7 +97,7 @@ exports[`EuiSideNavItem href is rendered with rel 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button />
       </span>
@@ -55,7 +117,7 @@ exports[`EuiSideNavItem is rendered 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button
           aria-label="aria-label"
@@ -79,7 +141,7 @@ exports[`EuiSideNavItem isSelected defaults to false 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button />
       </span>
@@ -99,7 +161,7 @@ exports[`EuiSideNavItem isSelected is rendered when specified as true 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button />
       </span>
@@ -119,7 +181,7 @@ exports[`EuiSideNavItem preserves child's classes 1`] = `
       class="euiSideNavItemButton__content"
     >
       <span
-        class="euiSideNavItemButton__label"
+        class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
       >
         <button
           class="test"

--- a/src/components/side_nav/_index.scss
+++ b/src/components/side_nav/_index.scss
@@ -1,2 +1,4 @@
+@import 'variables';
+
 @import 'side_nav';
 @import 'side_nav_item';

--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -2,45 +2,16 @@
 .euiSideNav__mobileToggle {
   display: none;
   border-bottom: $euiBorderThin;
-  padding: $euiSize $euiSizeL;
+  padding: $euiSize;
   width: 100%;
   text-align: left;
+  border-radius: 0 !important; // sass-lint:disable-line no-important
 
-  /**
-   * 1. This toggle also works with EUI link, but we need the outline
-   *    that comes with the focus state.
-   */
-  &:focus {
-    outline: none;
+  .euiButtonContent {
+    justify-content: space-between;
   }
 }
 
-.euiSideNav__mobileIcon {
-  fill: $euiColorPrimary;
-}
-
-.euiSideNav__mobileWrap {
-  display: flex;
-}
-
-.euiSideNav__mobileTitle {
-  flex-grow: 1;
-  color: $euiColorPrimary;
-}
-
-.euiSideNav__hideButton {
-  width: $euiSizeL;
-  height: $euiSizeL;
-  border-radius: $euiBorderRadius;
-  border: $euiBorderThin;
-  background: $euiColorEmptyShade;
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  right: -$euiSizeXXL;
-  top: $euiSizeXL;
-}
 
 @include euiBreakpoint('xs', 's') {
   /**

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -1,37 +1,44 @@
 /**
  * 1. Text-align defaults to center, so we have to override that.
- * 2. Need this on the button element to color the underline.
+ * 2. Color the text at the item level and then have the button inherit so overrides are easier
+ * 3. Enable ellipsis overflow to work (https://css-tricks.com/flexbox-truncated-text/)
+ * 4. Restrict the underline to the button __label so it doesn't affect other components that might live within
  */
+
+
 .euiSideNavItemButton {
   @include euiFontSizeS;
   text-align: left; /* 1 */
   display: block;
   width: 100%;
   padding: $euiSizeXS / 2 0;
-  color: $euiTextColor; /* 2 */
+  color: inherit; /* 2 */
 
-  &.euiSideNavItemButton--isClickable {
-    &:hover .euiSideNavItemButton__label {
-      text-decoration: underline;
+  &.euiSideNavItemButton--isClickable:not(:disabled) {
+    &:hover {
+      cursor: pointer;
     }
 
-    // Focus state background regardless of index/selected state.
+    &:hover,
     &:focus {
-      // sass-lint:disable-block no-important
-      background-color: $euiFocusBackgroundColor !important;
+      .euiSideNavItemButton__label {
+        // A lingering focus will stay underlined even if it doesn't get the `isSelected` prop
+        text-decoration: underline; /* 4 */
+      }
     }
   }
 
   &.euiSideNavItemButton-isSelected {
-    .euiSideNavItemButton__icon {
-      fill: $euiColorPrimary;
-    }
+    color: $euiSideNavSelectedTextcolor;
+    font-weight: $euiFontWeightBold;
 
     .euiSideNavItemButton__label {
-      color: $euiColorPrimary;
-      font-weight: $euiFontWeightBold;
-      text-decoration: underline;
+      text-decoration: underline; /* 4 */
     }
+  }
+
+  &:disabled {
+    @include euiDisabledState;
   }
 }
 
@@ -44,36 +51,16 @@
   margin-right: $euiSizeS;
 }
 
-/**
-  * 1. Enable ellipsis overflow to work (https://css-tricks.com/flexbox-truncated-text/)
-  */
 .euiSideNavItemButton__labelContainer {
-  min-width: 0; /* 1 */
+  min-width: 0; /* 3 */
 }
 
 .euiSideNavItemButton__label {
-  color: $euiTitleColor;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   flex-grow: 1;
 }
 
-/**
- * 1. Draw the vertical line to group an expanded item's child items together.
- */
-.euiSideNavItem__items {
-  position: relative;
-
-  &:after { /* 1 */
-    position: absolute;
-    content: '';
-    top: 0;
-    bottom: $euiSizeM;
-    width: 1px;
-    background: $euiBorderColor;
-    left: 0;
-  }
+.euiSideNavItemButton__label--truncated {
+  @include euiTextTruncate;
 }
 
 .euiSideNavItem--root {
@@ -94,9 +81,9 @@
 
     .euiSideNavItemButton__label {
       @include euiTitle('xs');
+      color: inherit;
     }
   }
-
 
   & > .euiSideNavItem__items {
     position: static;
@@ -113,6 +100,8 @@
 }
 
 .euiSideNavItem--trunk {
+  color: $euiSideNavRootTextcolor; /* 2 */
+
   /**
    * 1. Create padding around focus area without indenting the item itself.
    */
@@ -131,17 +120,38 @@
 
 .euiSideNavItem--branch {
   /**
-   * 1. Absolutely position the horizontal tick connecting the item to the vertical line.
+  * 1. Draw the vertical line to group an expanded item's child items together.
+  */
+  position: relative;
+  color: $euiSideNavBranchTextcolor; /* 2 */
+
+  &::after { /* 1 */
+    position: absolute;
+    content: '';
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: $euiBorderColor;
+    left: 0;
+  }
+
+  // If this is actually the last item, we don't want the vertical line to stretch all the way down
+  &:last-of-type::after {
+    height: $euiSizeM;
+  }
+
+  /**
+   * 2. Absolutely position the horizontal tick connecting the item to the vertical line.
    */
   & > .euiSideNavItemButton {
-    position: relative; /* 1 */
+    position: relative; /* 2 */
     padding-left: $euiSizeS;
-    padding-right: $euiSizeS; /* 1 */
+    padding-right: $euiSizeS; /* 2 */
 
     &:after {
-      position: absolute; /* 1 */
+      position: absolute; /* 2 */
       content: '';
-      top: 50%;
+      top: $euiSizeM;
       left: 0;
       width: $euiSizeXS;
       height: 1px;
@@ -152,13 +162,21 @@
   & > .euiSideNavItem__items {
     margin-left: $euiSize;
   }
-
-  .euiSideNavItemButton__icon {
-    fill: $euiTextSubduedColor;
-  }
-
-  .euiSideNavItemButton__label {
-    color: $euiTextSubduedColor;
-  }
 }
 
+.euiSideNavItem--emphasized {
+  background: $euiSideNavEmphasizedBackgroundColor;
+  color: $euiSideNavRootTextcolor;
+  // The large y values allow the shadow to stretch beyond the side nav bounds to it's parents container
+  box-shadow: 100px 0 0 0 $euiSideNavEmphasizedBackgroundColor, -100px 0 0 0 $euiSideNavEmphasizedBackgroundColor;
+
+  > .euiSideNavItemButton {
+    font-weight: $euiFontWeightBold;
+  }
+
+  // Remove any extra box-shadows from nested emphasized items
+  .euiSideNavItem--emphasized {
+    background: transparent;
+    box-shadow: none;
+  }
+}

--- a/src/components/side_nav/_variables.scss
+++ b/src/components/side_nav/_variables.scss
@@ -1,0 +1,6 @@
+$euiSideNavEmphasizedBackgroundColor: tintOrShade($euiColorLightShade, 64%, 28%);
+
+// Ensure all the possible text color have proper contrast when "emphasized"
+$euiSideNavRootTextcolor: makeHighContrastColor($euiTitleColor, $euiSideNavEmphasizedBackgroundColor);
+$euiSideNavBranchTextcolor: makeHighContrastColor($euiTextSubduedColor, $euiSideNavEmphasizedBackgroundColor);
+$euiSideNavSelectedTextcolor: makeHighContrastColor($euiColorPrimary, $euiSideNavEmphasizedBackgroundColor);

--- a/src/components/side_nav/index.ts
+++ b/src/components/side_nav/index.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export { EuiSideNav } from './side_nav';
+export { EuiSideNav, EuiSideNavProps } from './side_nav';
 
 export * from './side_nav_types';

--- a/src/components/side_nav/side_nav.test.tsx
+++ b/src/components/side_nav/side_nav.test.tsx
@@ -55,10 +55,15 @@ describe('EuiSideNav', () => {
             items: [
               {
                 name: 'B',
+                className: 'class',
+                'data-test-sub': 'dts',
+                'aria-label': 'aria',
                 id: 1,
               },
               {
                 name: 'C',
+                truncate: false,
+                emphasize: true,
                 id: 2,
                 items: [
                   {
@@ -67,6 +72,7 @@ describe('EuiSideNav', () => {
                   },
                   {
                     name: 'E',
+                    disabled: true,
                     id: 4,
                   },
                 ],

--- a/src/components/side_nav/side_nav.tsx
+++ b/src/components/side_nav/side_nav.tsx
@@ -22,10 +22,9 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 
-import { EuiIcon } from '../icon';
-
 import { EuiSideNavItem, RenderItem } from './side_nav_item';
 import { EuiSideNavItemType } from './side_nav_types';
+import { EuiButtonEmpty } from '../button';
 
 export type EuiSideNavProps<T> = T &
   CommonProps & {
@@ -57,6 +56,10 @@ export type EuiSideNavProps<T> = T &
      * Overrides default navigation menu item rendering. When called, it should return a React node representing a replacement navigation item.
      */
     renderItem?: RenderItem<T>;
+    /**
+     * Truncates the text of all items to stick to a single line
+     */
+    truncate?: boolean;
   };
 
 export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
@@ -84,7 +87,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
   };
 
   renderTree = (items: Array<EuiSideNavItemType<T>>, depth = 0) => {
-    const { renderItem } = this.props;
+    const { renderItem, truncate } = this.props;
 
     return items.map((item) => {
       const {
@@ -120,6 +123,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
           key={id}
           depth={depth}
           renderItem={renderItem}
+          truncate={truncate}
           {...rest}>
           {name}
         </EuiSideNavItem>
@@ -136,6 +140,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
       mobileTitle,
       // Extract this one out so it isn't passed to <nav>
       renderItem,
+      truncate,
       ...rest
     } = this.props;
 
@@ -148,21 +153,13 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     return (
       <nav className={classes} {...rest}>
         {/* Hidden from view, except in mobile */}
-        <button
-          type="button"
-          className="euiSideNav__mobileToggle euiLink"
-          onClick={toggleOpenOnMobile}>
-          <span className="euiSideNav__mobileWrap">
-            <span className="euiSideNav__mobileTitle">{mobileTitle}</span>
-
-            <EuiIcon
-              className="euiSideNav__mobileIcon"
-              type="apps"
-              size="m"
-              aria-hidden="true"
-            />
-          </span>
-        </button>
+        <EuiButtonEmpty
+          className="euiSideNav__mobileToggle"
+          onClick={toggleOpenOnMobile}
+          iconType="apps"
+          iconSide="right">
+          {mobileTitle}
+        </EuiButtonEmpty>
 
         {/* Hidden from view in mobile, but toggled from the button above */}
         <div className="euiSideNav__content">{nav}</div>

--- a/src/components/side_nav/side_nav_item.test.tsx
+++ b/src/components/side_nav/side_nav_item.test.tsx
@@ -44,6 +44,30 @@ describe('EuiSideNavItem', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('can have truncation turned off', () => {
+    const component = render(
+      <EuiSideNavItem truncate={false}>Children</EuiSideNavItem>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('can be emphasized', () => {
+    const component = render(
+      <EuiSideNavItem emphasize>Children</EuiSideNavItem>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('can be disabled', () => {
+    const component = render(
+      <EuiSideNavItem disabled>Children</EuiSideNavItem>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('isSelected', () => {
     test('defaults to false', () => {
       const component = render(

--- a/src/components/side_nav/side_nav_types.ts
+++ b/src/components/side_nav/side_nav_types.ts
@@ -17,11 +17,17 @@
  * under the License.
  */
 
-import { ReactElement, ReactNode, MouseEventHandler } from 'react';
+import { ReactNode } from 'react';
 
-import { RenderItem } from './side_nav_item';
+import {
+  RenderItem,
+  _EuiSideNavItemButtonProps,
+  _EuiSideNavItemProps,
+} from './side_nav_item';
 
-export interface EuiSideNavItemType<T> {
+export interface EuiSideNavItemType<T>
+  extends Omit<_EuiSideNavItemButtonProps, 'children'>,
+    Omit<_EuiSideNavItemProps, 'isParent' | 'depth' | 'isOpen'> {
   /**
    * A value that is passed to React as the `key` for this item
    */
@@ -31,20 +37,6 @@ export interface EuiSideNavItemType<T> {
    */
   forceOpen?: boolean;
   /**
-   * Is an optional string to be passed as the navigation item's `href` prop, and by default it will force rendering of the item as an `<a>`.
-   */
-  href?: string;
-  target?: string;
-  rel?: string;
-  /**
-   * React node which will be rendered as a small icon to the left of the navigation item text.
-   */
-  icon?: ReactElement;
-  /**
-   * If set to true it will render the item in a visible "selected" state, and will force all ancestor navigation items to render in an "open" state.
-   */
-  isSelected?: boolean;
-  /**
    * Array containing additional item objects, representing nested children of this navigation item.
    */
   items?: Array<EuiSideNavItemType<T>>;
@@ -52,10 +44,6 @@ export interface EuiSideNavItemType<T> {
    * React node representing the text to render for this item (usually a string will suffice).
    */
   name: ReactNode;
-  /**
-   * Callback function to be passed as the navigation item's `onClick` prop, and by default it will force rendering of the item as a `<button>` instead of a link.
-   */
-  onClick?: MouseEventHandler<HTMLButtonElement>;
   /**
    * Function overriding default rendering for this navigation item — when called, it should return a React node representing a replacement navigation item.
    */

--- a/src/themes/eui-amsterdam/global_styling/mixins/_typography.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_typography.scss
@@ -1,5 +1,16 @@
 // Font sizing extends, using rem mixin
 // All line-heights are aligned to baseline grid
+// sass-lint:disable no-vendor-prefixes
+
+// Redoing this mixin mainly to remove the letter-spacing
+@mixin euiFont {
+  font-family: $euiFontFamily;
+  font-weight: $euiFontWeightRegular;
+  letter-spacing: normal;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  font-kerning: normal;
+}
 
 @mixin euiFontSizeXS {
   @include fontSize($euiFontSizeXS);


### PR DESCRIPTION
* Fix nested indicator when item is the last one
* Re-arranging text color styles for easier className overrides
* Added `truncate` prop to items and the list
   - Including `innerText` for `titles` when truncation is on
* Added `emphasize` prop to item for adding background and bold button
* Added `disabled` state to items and fixed up some other interaction state styles
* Fixed mobile button

### Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
