### PR TITLE
Fixed disabled text styles in Safari (and iOS) (#4538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed override possibility of text `color` in `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
 - Fixed blurry animation of popovers in Chrome ([#4527](https://github.com/elastic/eui/pull/4527))
 - Fixed styles of `disabled` times in `EuiDatePicker` ([#4524](https://github.com/elastic/eui/pull/4524))
+- Fixed `disabled` text color form fields in Safari ([#4538](https://github.com/elastic/eui/pull/4538))
 
 **Theme: Amsterdam**
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -195,8 +195,10 @@
 }
 
 @mixin euiFormControlDisabledStyle {
+  // sass-lint:disable-block no-vendor-prefixes
   cursor: not-allowed;
   color: $euiFormControlDisabledColor;
+  -webkit-text-fill-color: $euiFormControlDisabledColor; // Required for Safari
   background: $euiFormBackgroundDisabledColor;
   box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -104,6 +104,10 @@ a:hover, button, [role='button'] {
 input {
   margin: 0;
   padding: 0;
+
+  &:disabled {
+    opacity: 1; /* required on iOS */
+  }
 }
 
 button {

--- a/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
+++ b/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
@@ -110,6 +110,10 @@ a:hover, button, [role='button'] {
 input {
   margin: 0;
   padding: 0;
+
+  &:disabled {
+    opacity: 1; /* required on iOS */
+  }
 }
 
 button {


### PR DESCRIPTION
### Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
